### PR TITLE
pageYOffset provides better cross-browser support

### DIFF
--- a/www/scripts/triggers.js
+++ b/www/scripts/triggers.js
@@ -161,7 +161,7 @@ TRIGGERS.DetailsViewHandler = (function() {
   }
 
   function onScrollWindow() {
-    if (window.scrollY > 338)
+    if (window.pageYOffset > 338)
       detailsView.classList.add('sticky');
     else
       detailsView.classList.remove('sticky');


### PR DESCRIPTION
The sticky class is presently not applied in Internet Explorer due to a lack of support for `window.scrollY`. Per the MDN documentation, it's encouraged that we use `.pageYOffset` (which the spec says should return scrollY's value) for better cross-browser support.