### PR TITLE
Add Gecko triggers and script for tests.

### DIFF
--- a/gecko.js
+++ b/gecko.js
@@ -1,864 +1,864 @@
 module.exports = {
   "data": {
     "align-content-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": false,
+      "layout": false,
+      "composite": true
     },
     "align-items-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "align-self-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "backface-visibility-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": false,
+      "layout": false,
+      "composite": true
     },
     "backface-visibility-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": false,
+      "layout": false,
+      "composite": true
     },
     "background-attachment-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": false,
+      "composite": true
     },
     "background-attachment-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": false,
+      "composite": true
     },
     "background-blend-mode-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": false,
+      "composite": true
     },
     "background-blend-mode-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": false,
+      "composite": true
     },
     "background-clip-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": false,
+      "composite": true
     },
     "background-color-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": false,
+      "composite": true
     },
     "background-color-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": false,
+      "composite": true
     },
     "background-image-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": false,
+      "composite": true
     },
     "background-image-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": false,
+      "composite": true
     },
     "background-origin-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": false,
+      "composite": true
     },
     "background-position-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": false,
+      "composite": true
     },
     "background-position-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": false,
+      "composite": true
     },
     "background-repeat-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": false,
+      "composite": true
     },
     "background-repeat-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": false,
+      "composite": true
     },
     "background-size-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": false,
+      "composite": true
     },
     "background-size-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": false,
+      "composite": true
     },
     "border-bottom-color-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": false,
+      "composite": true
     },
     "border-bottom-left-radius-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": false,
+      "composite": true
     },
     "border-bottom-left-radius-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": false,
+      "composite": true
     },
     "border-bottom-right-radius-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": false,
+      "composite": true
     },
     "border-bottom-right-radius-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": false,
+      "composite": true
     },
     "border-bottom-style-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "border-bottom-style-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "border-bottom-width-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "border-bottom-width-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "border-collapse-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "border-image-outset-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "border-image-outset-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "border-image-repeat-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": false,
+      "composite": true
     },
     "border-image-slice-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": false,
+      "composite": true
     },
     "border-image-slice-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": false,
+      "composite": true
     },
     "border-image-source-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": false,
+      "composite": true
     },
     "border-image-width-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": false,
+      "composite": true
     },
     "border-left-color-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": false,
+      "composite": true
     },
     "border-left-style-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "border-left-width-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "border-left-width-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "border-right-color-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": false,
+      "composite": true
     },
     "border-right-style-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "border-right-width-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "border-right-width-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "border-top-color-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": false,
+      "composite": true
     },
     "border-top-left-radius-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": false,
+      "composite": true
     },
     "border-top-left-radius-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": false,
+      "composite": true
     },
     "border-top-right-radius-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": false,
+      "composite": true
     },
     "border-top-right-radius-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": false,
+      "composite": true
     },
     "border-top-style-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "border-top-width-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "border-top-width-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "bottom-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "bottom-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "box-shadow-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "box-shadow-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "box-sizing-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "clear-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "clip-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "color-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": false,
+      "composite": true
     },
     "color-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": false,
+      "composite": true
     },
     "cursor-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": false,
+      "layout": false,
+      "composite": true
     },
     "direction-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "display-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "flex-basis-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "flex-direction-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "flex-direction-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "flex-grow-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "flex-grow-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "flex-shrink-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "flex-shrink-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "flex-wrap-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "flex-wrap-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "float-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "float-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "font-family-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "font-family-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "font-kerning-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "font-size-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "font-style-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "font-variant-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "font-variant-ligatures-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "font-weight-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "height-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "height-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "justify-content-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": false,
+      "layout": true,
+      "composite": true
     },
     "left-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "left-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "letter-spacing-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "line-height-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "list-style-image-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": false,
+      "layout": false,
+      "composite": true
     },
     "list-style-position-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "list-style-type-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "margin-bottom-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "margin-bottom-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "margin-left-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "margin-left-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "margin-right-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "margin-right-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "margin-top-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "margin-top-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "max-height-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "max-height-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "max-width-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "max-width-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "min-height-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "min-height-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "min-width-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": false,
+      "layout": true,
+      "composite": true
     },
     "min-width-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": false,
+      "layout": true,
+      "composite": true
     },
     "opacity-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": false,
+      "composite": true
     },
     "opacity-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": false,
+      "composite": true
     },
     "order-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "order-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "orphans-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": false,
+      "layout": false,
+      "composite": true
     },
     "outline-color-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": false,
+      "composite": true
     },
     "outline-offset-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": false,
+      "composite": true
     },
     "outline-offset-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": false,
+      "composite": true
     },
     "outline-style-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": false,
+      "composite": true
     },
     "outline-width-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": false,
+      "composite": true
     },
     "outline-width-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": false,
+      "composite": true
     },
     "overflow-wrap-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": false,
+      "layout": false,
+      "composite": true
     },
     "overflow-x-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "overflow-x-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "overflow-y-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "overflow-y-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "padding-bottom-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "padding-bottom-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "padding-left-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "padding-left-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "padding-right-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "padding-right-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "padding-top-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "padding-top-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "perspective-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": false,
+      "layout": false,
+      "composite": true
     },
     "perspective-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": false,
+      "layout": false,
+      "composite": true
     },
     "perspective-origin-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": false,
+      "layout": false,
+      "composite": true
     },
     "perspective-origin-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": false,
+      "layout": false,
+      "composite": true
     },
     "pointer-events-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "position-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "resize-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "right-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "right-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "table-layout-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "text-align-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "text-decoration-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": false,
+      "composite": true
     },
     "text-indent-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "text-indent-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "text-rendering-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "text-rendering-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "text-shadow-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "text-shadow-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "text-transform-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "top-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "top-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "transform-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "transform-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "transform-origin-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": false,
+      "layout": false,
+      "composite": true
     },
     "transform-origin-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": false,
+      "layout": false,
+      "composite": true
     },
     "transform-style-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": false,
+      "composite": true
     },
     "unicode-bidi-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "vertical-align-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "visibility-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": false,
+      "composite": true
     },
     "white-space-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "widows-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": false,
+      "layout": false,
+      "composite": true
     },
     "width-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "word-break-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "word-spacing-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "word-wrap-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": true,
+      "composite": true
     },
     "z-index-change": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": false,
+      "composite": true
     },
     "z-index-initial": {
-      "layout": null,
-      "paint": null,
-      "composite": null
+      "paint": true,
+      "layout": false,
+      "composite": true
     }
   }
 };

--- a/vendor-scripts/gecko/scratchpad.js
+++ b/vendor-scripts/gecko/scratchpad.js
@@ -1,0 +1,80 @@
+/**
+ * Enable chrome debugging (`devtools.chrome.enabled` in about:config) and open a scratchpad context (Tools > Web Developer > Scratchpad). In Scratchpad, if chrome debugging is enabled, go to 'Environment' in the menu and select "Browser" to execute this script in the browser context. Paste the following script after updating REPO_URL, and hit the "execute" button. A new tab with data will open when it's done.
+ *
+ * Note, this requires single-process Firefox to run; we need a multi-process version very soon.
+ */
+
+(function() {
+  const REPO_URL = "file:///home/paul/github/CSS-Triggers/";
+  let tab = gBrowser.selectedTab = gBrowser.addTab();
+  let contentWindow = tab.linkedBrowser.contentWindow;
+  let docshell = contentWindow.QueryInterface(Ci.nsIInterfaceRequestor).getInterface(Ci.nsIWebNavigation);
+  docshell.recordProfileTimelineMarkers = true;
+
+  let req = new XMLHttpRequest();
+  req.overrideMimeType('text/plain');
+  let tests = [];
+  let testsCursor = 0;
+  let res = {};
+
+  req.onerror = () => alert("Can't fetch gecko.js");
+  req.onload = () => {
+    try {
+      let sandbox = new Cu.Sandbox(window, {sandboxPrototype:{module:{}}});
+      sandbox.module = {};
+      Cu.evalInSandbox(req.response, sandbox);
+      let data = sandbox.module.exports.data;
+      for (let key in data) {
+        tests.push(key);
+      }
+      runNextTest();
+    } catch(e) {console.error(e)}
+  }
+
+  req.open("get", REPO_URL + "gecko.js", true);
+  req.send();
+
+  function runNextTest() {
+    if (testsCursor >= tests.length) {
+      return finishTests();
+    }
+
+    let file = tests[testsCursor++];
+    let url = REPO_URL + "/suite/" + file + ".html";
+
+    console.log("running test:", file)
+
+    tab.linkedBrowser.addEventListener("load", function onLoad() {
+      contentWindow = tab.linkedBrowser.contentWindow;
+      contentWindow = XPCNativeWrapper.unwrap(contentWindow);
+      tab.linkedBrowser.removeEventListener("load", onLoad, true);
+      setTimeout(() => {
+        docshell.popProfileTimelineMarkers();
+        contentWindow.go();
+        isTestDone();
+      }, 200);
+    }, true);
+
+    contentWindow.location = url;
+
+    function isTestDone() {
+      let timeout = window.setTimeout(() => {
+        if (contentWindow.isDone) {
+          let markers = docshell.popProfileTimelineMarkers();
+          markers = markers.filter(m => !!m);
+          let r = res[file] = {};
+          r.paint = markers.some(m => (m.name == "Paint"));
+          r.layout = markers.some(m => (m.name == "Reflow"));
+          r.composite = true;
+          runNextTest();
+        } else {
+          isTestDone();
+        }
+      }, 100);
+    }
+  }
+
+  function finishTests() {
+    gBrowser.addTab("data:text/plain;charset=utf-8," + JSON.stringify(res,null,2));
+  }
+})()


### PR DESCRIPTION
Follow up for @paulrouget's #4 on gecko data

In terms of the differences between this and Paul's initial gecko data, we have paint markers for:
justify-content-initial
mid-width-change

And layout markers for:

outline-offset-change
outline-offset-initial
outline-style-initial
outline-width-change
outline-width-initial

Dump of fields that differ between chromium and gecko

align-content-initial layout: chromium true, gecko false
align-content-initial paint: chromium true, gecko false
backface-visibility-initial paint: chromium true, gecko false
border-bottom-style-change layout: chromium false, gecko true
border-bottom-style-initial layout: chromium false, gecko true
border-image-outset-change layout: chromium false, gecko true
border-image-outset-initial layout: chromium false, gecko true
border-left-style-initial layout: chromium false, gecko true
border-right-style-initial layout: chromium false, gecko true
border-top-style-initial layout: chromium false, gecko true
box-shadow-change layout: chromium false, gecko true
box-shadow-initial layout: chromium false, gecko true
clip-initial layout: chromium false, gecko true
cursor-initial layout: chromium true, gecko false
cursor-initial paint: chromium true, gecko false
justify-content-initial paint: chromium true, gecko false
list-style-image-initial layout: chromium true, gecko false
list-style-image-initial paint: chromium true, gecko false
min-width-change paint: chromium true, gecko false
min-width-initial paint: chromium true, gecko false
opacity-change paint: chromium false, gecko true
orphans-initial layout: chromium true, gecko false
orphans-initial paint: chromium true, gecko false
outline-color-initial layout: chromium true, gecko false
outline-offset-change layout: chromium true, gecko false
outline-style-initial layout: chromium true, gecko false
outline-width-change layout: chromium true, gecko false
outline-width-initial layout: chromium true, gecko false
overflow-wrap-initial layout: chromium true, gecko false
overflow-wrap-initial paint: chromium true, gecko false
resize-initial paint: chromium false, gecko true
text-decoration-initial layout: chromium true, gecko false
text-shadow-change layout: chromium false, gecko true
text-shadow-initial layout: chromium false, gecko true
transform-change layout: chromium false, gecko true
transform-change paint: chromium false, gecko true
transform-initial layout: chromium false, gecko true
transform-initial paint: chromium false, gecko true
transform-origin-change paint: chromium true, gecko false
transform-origin-initial paint: chromium true, gecko false
transform-style-initial paint: chromium false, gecko true
visibility-initial layout: chromium true, gecko false
widows-initial layout: chromium true, gecko false
widows-initial paint: chromium true, gecko false